### PR TITLE
Add tests for clay http.request

### DIFF
--- a/py_look_for_timeouts/main.py
+++ b/py_look_for_timeouts/main.py
@@ -106,6 +106,15 @@ class Checker(ast.NodeVisitor):
             return True
         return False
 
+    @staticmethod
+    def _is_clay_call(function_name):
+        if '.' in function_name:
+            if function_name.endswith('http.request'):
+                return True
+        elif function_name == 'request':
+            return True
+        return False
+
     def _check_timeout_call(self, node, arg_offset, kwarg_name, desc):
         if arg_offset is not None and len(node.args) > arg_offset:
             if _intify(node.args[arg_offset]) == 0:
@@ -158,6 +167,13 @@ class Checker(ast.NodeVisitor):
                 arg_offset=None,
                 kwarg_name='timeout',
                 desc='requests call'
+            )
+        elif self._is_clay_call(function_name):
+            self._check_timeout_call(
+                node,
+                arg_offset=4,
+                kwarg_name='timeout',
+                desc='http call'
             )
 
 

--- a/tests/samples/bad_clay_requests.py
+++ b/tests/samples/bad_clay_requests.py
@@ -1,0 +1,10 @@
+import clay
+from clay import http
+
+c = request('method', 'foo', 'data', 'headers', 0)
+c = request('method', 'foo')
+c = request('method', 'foo', timeout=0)
+
+c = http.request('method', 'foo', 'data', 'headers', 0)
+c = http.request('method', 'foo')
+c = http.request('method', 'foo', timeout=0)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -49,3 +49,13 @@ class TestSimple(TestCase):
     def test_bad_requests_call(self):
         errors = check(join(SAMPLE_PATH, 'bad_requests.py'))
         self.assertEqual(len(errors), 5)
+
+    def test_bad_clay_requests(self):
+        errors = check(join(SAMPLE_PATH, 'bad_clay_requests.py'))
+        self.assertEqual(len(errors), 6)
+        self.assertEqual(errors[0].reason, 'http call with a timeout arg of 0')
+        self.assertEqual(errors[1].reason, 'http call without a timeout arg or kwarg')
+        self.assertEqual(errors[2].reason, 'http call with a timeout kwarg of 0')
+        self.assertEqual(errors[3].reason, 'http call with a timeout arg of 0')
+        self.assertEqual(errors[4].reason, 'http call without a timeout arg or kwarg')
+        self.assertEqual(errors[5].reason, 'http call with a timeout kwarg of 0')


### PR DESCRIPTION
Clay's http wraps urllib2 creating another way to do a request with no timeout
