### PR TITLE
run flake8 during travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ python:
     - "2.7"
 install:
     - "pip install -r requirements-tests.txt"
-script: "nosetests -s -v --with-cover --cover-package=py_look_for_timeouts tests"
+script:
+    - "flake8 setup.py py_look_for_timeouts tests"
+    - "nosetests -s -v --with-cover --cover-package=py_look_for_timeouts tests"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,4 @@
 mock==1.0.1
 nose==1.3.3
 nose-cov==1.6
+flake8==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=120


### PR DESCRIPTION
should prevent some kinds of silly errors
